### PR TITLE
Improve PR deployment cleanup in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -55,7 +55,10 @@ jobs:
         if: github.event.action == 'closed'
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
-          docker compose -f docker/prod/docker-compose.pr.yml down
+          # Stop and remove only the PR-specific containers
+          docker stop pr-${PR_NUMBER}-web pr-${PR_NUMBER}-webrtc pr-${PR_NUMBER}-nginx || true
+          docker rm pr-${PR_NUMBER}-web pr-${PR_NUMBER}-webrtc pr-${PR_NUMBER}-nginx || true
+          # Remove PR-specific images
           docker rmi tafu-web:pr-${PR_NUMBER} || true
           docker rmi tafu-webrtc:pr-${PR_NUMBER} || true
           docker rmi tafu-nginx:pr-${PR_NUMBER} || true


### PR DESCRIPTION
- Replace docker-compose down with targeted container and image removal
- Add explicit stop and remove commands for PR-specific containers
- Ensure cleanup of web, webrtc, and nginx containers and images
- Enhance robustness of PR environment teardown process